### PR TITLE
feat(world): implement world generation and UI controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@typescript-eslint/parser": "^6.7.0",
         "@vitejs/plugin-react": "*",
         "eslint": "^8.56.0",
+        "tsx": "^4.7.0",
         "typescript": "*",
         "vite": "*",
         "vitest": "^1.0.0"
@@ -2931,6 +2932,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -3985,6 +3999,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -4419,6 +4443,26 @@
       },
       "peerDependencies": {
         "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.20.5",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.5.tgz",
+      "integrity": "sha512-+wKjMNU9w/EaQayHXb7WA7ZaHY6hN8WgfvHNQ3t1PnU91/7O8TcTnIhCDYTZwnt8JsO9IBqZ30Ln1r7pPF52Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/tunnel-rat": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",
-    "lint": "eslint . --ext .ts,.tsx"
+    "lint": "eslint . --ext .ts,.tsx",
+    "bench:world": "tsx scripts/benchWorld.ts"
   },
   "dependencies": {
     "react": "*",
@@ -24,6 +25,7 @@
     "vitest": "^1.0.0",
     "eslint": "^8.56.0",
     "@typescript-eslint/parser": "^6.7.0",
-    "@typescript-eslint/eslint-plugin": "^6.7.0"
+    "@typescript-eslint/eslint-plugin": "^6.7.0",
+    "tsx": "^4.7.0"
   }
 }

--- a/plan/feature-core-game-foundation-1.md
+++ b/plan/feature-core-game-foundation-1.md
@@ -4,7 +4,7 @@ version: 1.0
 date_created: 2025-09-08
 last_updated: 2025-09-08
 owner: deadronos
-status: Planned
+status: In Progress
 tags: [feature, game, foundation, architecture, implementation-plan]
 ---
 
@@ -46,7 +46,7 @@ src/
 ```
 
 
-![Status: Planned](https://img.shields.io/badge/status-Planned-blue)
+![Status: In Progress](https://img.shields.io/badge/status-In%20Progress-yellow)
 
 This implementation plan operationalizes the requirements (REQ-001..REQ-020, SEC-001..SEC-003, PER-001..PER-003, CON/GUD/PAT) defined in `spec/spec-architecture-civweb-lite-core.md` into deterministic, atomic tasks with explicit dependencies, validation criteria, and deliverables. Execution order enforces foundational purity (state & RNG) before higher-level features (AI, persistence, UI). All tasks are designed for autonomous execution by an agent or human without further interpretation.
 
@@ -87,27 +87,31 @@ This implementation plan operationalizes the requirements (REQ-001..REQ-020, SEC
 
 | Task | Description | Completed | Date |
 |------|-------------|-----------|------|
-| TASK-001 | Create `src/game/types.ts` defining GameState, Tile, PlayerState, TechNode, enums (no logic) |  |  |
-| TASK-002 | Implement `src/game/rng.ts` deterministic RNG wrapper (seed in, next() pure) |  |  |
-| TASK-003 | Implement `src/game/events.ts` minimal typed event emitter (turn:start, turn:end, action:applied) |  |  |
-| TASK-004 | Implement immutable state helper `produceNextState(current, mutator)` (shallow structural sharing) |  |  |
-| TASK-005 | Scaffold `GameProvider` context returning `{ state, dispatch }` with initial empty state + seed placeholder |  |  |
-| TASK-006 | Add `useGame()` hook exposing read-only state (Object.freeze) + dispatch wrapper |  |  |
-| TASK-007 | Add unit tests for RNG determinism & event bus (Vitest) |  |  |
-| TASK-008 | Add ESLint rule/config (if absent) to prevent direct Math.random() in `src/game` |  |  |
+| TASK-001 | Create `src/game/types.ts` defining GameState, Tile, PlayerState, TechNode, enums (no logic) | ✅ | 2025-09-08 |
+| TASK-002 | Implement `src/game/rng.ts` deterministic RNG wrapper (seed in, next() pure) | ✅ | 2025-09-08 |
+| TASK-003 | Implement `src/game/events.ts` minimal typed event emitter (turn:start, turn:end, action:applied) | ✅ | 2025-09-08 |
+| TASK-004 | Implement immutable state helper `produceNextState(current, mutator)` (shallow structural sharing) | ✅ | 2025-09-08 |
+| TASK-005 | Scaffold `GameProvider` context returning `{ state, dispatch }` with initial empty state + seed placeholder | ✅ | 2025-09-08 |
+| TASK-006 | Add `useGame()` hook exposing read-only state (Object.freeze) + dispatch wrapper | ✅ | 2025-09-08 |
+| TASK-007 | Add unit tests for RNG determinism & event bus (Vitest) | ✅ | 2025-09-08 |
+| TASK-008 | Add ESLint rule/config (if absent) to prevent direct Math.random() in `src/game` | ✅ | 2025-09-08 |
+
+All tasks in Phase 1 are complete. No remaining items.
 
 ### Implementation Phase 2
 - GOAL-002: World generation system (map + biome assignment) meeting REQ-001, REQ-002, PAT-005.
 
 | Task | Description | Completed | Date |
 |------|-------------|-----------|------|
-| TASK-009 | Create `src/game/world/config.ts` with biome definitions & thresholds |  |  |
-| TASK-010 | Implement axial coordinate utilities `hex.ts` (distance, neighbors) |  |  |
-| TASK-011 | Implement `generateWorld(seed, width, height)` producing tiles with biome/elevation/moisture |  |  |
-| TASK-012 | Integrate world generation into initial GameState (GameProvider init) |  |  |
-| TASK-013 | Add statistical test verifying ≥5 biome presence for 30x30 default |  |  |
-| TASK-014 | Add performance benchmark capturing generation time (baseline log) |  |  |
-| TASK-015 | Expose seed & map dimensions via UI stub (no styling) |  |  |
+| TASK-009 | Create `src/game/world/config.ts` with biome definitions & thresholds | ✅ | 2025-09-08 |
+| TASK-010 | Implement axial coordinate utilities `hex.ts` (distance, neighbors) | ✅ | 2025-09-08 |
+| TASK-011 | Implement `generateWorld(seed, width, height)` producing tiles with biome/elevation/moisture | ✅ | 2025-09-08 |
+| TASK-012 | Integrate world generation into initial GameState (GameProvider init) | ✅ | 2025-09-08 |
+| TASK-013 | Add statistical test verifying ≥5 biome presence for 30x30 default | ✅ | 2025-09-08 |
+| TASK-014 | Add performance benchmark capturing generation time (baseline log) | ✅ | 2025-09-08 |
+| TASK-015 | Expose seed & map dimensions via UI stub (no styling) | ✅ | 2025-09-08 |
+
+All tasks in Phase 2 are complete. Proceed to Phase 3 for turn engine work.
 
 ### Implementation Phase 3
 - GOAL-003: Turn engine & action dispatch orchestration (REQ-003, REQ-012, REQ-019, PAT-002).

--- a/scripts/benchWorld.ts
+++ b/scripts/benchWorld.ts
@@ -1,0 +1,7 @@
+import { performance } from 'node:perf_hooks';
+import { generateWorld } from '../src/game/world/generate';
+
+const start = performance.now();
+generateWorld('benchmark', 30, 30);
+const end = performance.now();
+console.log(`World generation 30x30 took ${(end - start).toFixed(2)}ms`);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,9 +7,37 @@ import Scene from './scene/Scene';
 
 function UI() {
   const { state, dispatch } = useGame();
+  const [seed, setSeed] = React.useState(state.seed);
+  const [width, setWidth] = React.useState(state.map.width);
+  const [height, setHeight] = React.useState(state.map.height);
   return (
     <div className="ui">
+      <div>
+        Seed: <input value={seed} onChange={(e) => setSeed(e.target.value)} />
+        Width:{' '}
+        <input
+          type="number"
+          value={width}
+          onChange={(e) => setWidth(Number(e.target.value))}
+        />
+        Height:{' '}
+        <input
+          type="number"
+          value={height}
+          onChange={(e) => setHeight(Number(e.target.value))}
+        />
+        <button
+          onClick={() =>
+            dispatch({ type: 'INIT', payload: { seed, width, height } })
+          }
+        >
+          Regenerate
+        </button>
+      </div>
       <div>Turn: {state.turn}</div>
+      <div>
+        Map: {state.map.width}x{state.map.height}
+      </div>
       <button onClick={() => dispatch({ type: 'END_TURN' })}>End Turn</button>
     </div>
   );

--- a/src/contexts/GameProvider.tsx
+++ b/src/contexts/GameProvider.tsx
@@ -1,9 +1,11 @@
-import React, { createContext, useReducer, useMemo } from 'react';
+import React, { createContext, useReducer, useMemo, useEffect } from 'react';
 import type { ReactNode } from 'react';
-import { seedFrom, RNGState } from '../game/rng';
+import { RNGState } from '../game/rng';
 import { globalGameBus } from '../game/events';
 import { GameState, GameAction, Tile, PlayerState, TechNode } from '../game/types';
 import { produceNextState } from '../game/state';
+import { generateWorld } from '../game/world/generate';
+import { DEFAULT_MAP_SIZE } from '../game/world/config';
 
 export type Dispatch = (action: GameAction) => void;
 
@@ -14,7 +16,7 @@ const initialState = (): GameState => ({
   schemaVersion: 1,
   seed: 'default',
   turn: 0,
-  map: { width: 0, height: 0, tiles: [] as Tile[] },
+  map: { width: DEFAULT_MAP_SIZE.width, height: DEFAULT_MAP_SIZE.height, tiles: [] as Tile[] },
   players: [] as PlayerState[],
   techCatalog: [] as TechNode[],
   rngState: undefined as RNGState | undefined,
@@ -27,8 +29,12 @@ function reducer(state: GameState, action: GameAction): GameState {
     switch (action.type) {
       case 'INIT': {
         const seed = action.payload?.seed ?? draft.seed;
+        const width = action.payload?.width ?? draft.map.width;
+        const height = action.payload?.height ?? draft.map.height;
         draft.seed = seed;
-        draft.rngState = seedFrom(seed);
+        const world = generateWorld(seed, width, height);
+        draft.map = { width, height, tiles: world.tiles };
+        draft.rngState = world.state;
         globalGameBus.emit('action:applied', { action });
         globalGameBus.emit('turn:start', { turn: draft.turn });
         break;
@@ -47,6 +53,9 @@ function reducer(state: GameState, action: GameAction): GameState {
 
 export function GameProvider({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(reducer, undefined, initialState);
+  useEffect(() => {
+    dispatch({ type: 'INIT' });
+  }, [dispatch]);
   const frozen = useMemo(() => Object.freeze(state), [state]);
   return (
     <GameStateContext.Provider value={frozen}>

--- a/src/game/world/config.ts
+++ b/src/game/world/config.ts
@@ -1,0 +1,18 @@
+import { BiomeType } from '../types';
+
+export interface BiomeRule {
+  type: BiomeType;
+  elevation: [number, number];
+  moisture?: [number, number];
+}
+
+export const BIOME_RULES: BiomeRule[] = [
+  { type: BiomeType.Ocean, elevation: [0, 0.3] },
+  { type: BiomeType.Desert, elevation: [0.3, 0.6], moisture: [0, 0.4] },
+  { type: BiomeType.Grassland, elevation: [0.3, 0.6], moisture: [0.4, 1] },
+  { type: BiomeType.Tundra, elevation: [0.6, 0.8], moisture: [0, 0.4] },
+  { type: BiomeType.Forest, elevation: [0.6, 0.8], moisture: [0.4, 1] },
+  { type: BiomeType.Mountain, elevation: [0.8, 1] },
+];
+
+export const DEFAULT_MAP_SIZE = { width: 30, height: 30 };

--- a/src/game/world/generate.ts
+++ b/src/game/world/generate.ts
@@ -1,0 +1,46 @@
+import { seedFrom, next, RNGState } from '../rng';
+import { BiomeType, Tile } from '../types';
+import { BIOME_RULES, DEFAULT_MAP_SIZE } from './config';
+
+function pickBiome(elevation: number, moisture: number): BiomeType {
+  for (const rule of BIOME_RULES) {
+    if (
+      elevation >= rule.elevation[0] &&
+      elevation < rule.elevation[1] &&
+      (!rule.moisture ||
+        (moisture >= rule.moisture[0] && moisture < rule.moisture[1]))
+    ) {
+      return rule.type;
+    }
+  }
+  return BiomeType.Grassland;
+}
+
+export function generateWorld(
+  seed: string | RNGState,
+  width = DEFAULT_MAP_SIZE.width,
+  height = DEFAULT_MAP_SIZE.height,
+): { tiles: Tile[]; state: RNGState } {
+  let rng = typeof seed === 'string' ? seedFrom(seed) : seed;
+  const tiles: Tile[] = [];
+  for (let r = 0; r < height; r++) {
+    for (let q = 0; q < width; q++) {
+      const elevOut = next(rng);
+      rng = elevOut.state;
+      const elevation = elevOut.value;
+      const moistOut = next(rng);
+      rng = moistOut.state;
+      const moisture = moistOut.value;
+      const biome = pickBiome(elevation, moisture);
+      tiles.push({
+        id: `${q},${r}`,
+        coord: { q, r },
+        biome,
+        elevation,
+        moisture,
+        exploredBy: [],
+      });
+    }
+  }
+  return { tiles, state: rng };
+}

--- a/src/game/world/hex.ts
+++ b/src/game/world/hex.ts
@@ -1,0 +1,26 @@
+import { HexCoord } from '../types';
+
+export const HEX_DIRECTIONS: HexCoord[] = [
+  { q: 1, r: 0 },
+  { q: 1, r: -1 },
+  { q: 0, r: -1 },
+  { q: -1, r: 0 },
+  { q: -1, r: 1 },
+  { q: 0, r: 1 },
+];
+
+export function add(a: HexCoord, b: HexCoord): HexCoord {
+  return { q: a.q + b.q, r: a.r + b.r };
+}
+
+export function neighbors(c: HexCoord): HexCoord[] {
+  return HEX_DIRECTIONS.map((d) => add(c, d));
+}
+
+export function distance(a: HexCoord, b: HexCoord): number {
+  return (
+    Math.abs(a.q - b.q) +
+    Math.abs(a.q + a.r - b.q - b.r) +
+    Math.abs(a.r - b.r)
+  ) / 2;
+}

--- a/tests/world.test.ts
+++ b/tests/world.test.ts
@@ -1,0 +1,10 @@
+import { describe, it, expect } from 'vitest';
+import { generateWorld } from '../src/game/world/generate';
+
+describe('world generation', () => {
+  it('produces at least five biomes for 30x30 map', () => {
+    const { tiles } = generateWorld('test-seed', 30, 30);
+    const biomes = new Set(tiles.map(t => t.biome));
+    expect(biomes.size).toBeGreaterThanOrEqual(5);
+  });
+});


### PR DESCRIPTION
## Summary
- add biome config, hex utilities, and deterministic world generator
- integrate generated world into GameProvider and expose seed/map controls
- include biome coverage test and world-gen benchmark script
- update implementation plan to mark phases 1–2 complete

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run bench:world`


------
https://chatgpt.com/codex/tasks/task_e_68beaf67a9b8832ab2a46f40bf478eb6