### PR TITLE
feat: add tech tree and basic ai

### DIFF
--- a/src/game/ai/ai.ts
+++ b/src/game/ai/ai.ts
@@ -1,0 +1,24 @@
+import { GameAction } from '../actions';
+import { GameState, PlayerState, TechNode } from '../types';
+
+function chooseNextTech(player: PlayerState, state: GameState): TechNode | undefined {
+  const prefTree =
+    player.leader.scienceFocus >= player.leader.cultureFocus ? 'science' : 'culture';
+  const candidates = state.techCatalog.filter(t =>
+    t.tree === prefTree &&
+    !player.researchedTechIds.includes(t.id) &&
+    t.prerequisites.every(p => player.researchedTechIds.includes(p))
+  );
+  return candidates[0];
+}
+
+export function evaluateAI(player: PlayerState, state: GameState): GameAction[] {
+  const actions: GameAction[] = [];
+  if (!player.researching) {
+    const tech = chooseNextTech(player, state);
+    if (tech) {
+      actions.push({ type: 'SET_RESEARCH', playerId: player.id, payload: { techId: tech.id } });
+    }
+  }
+  return actions;
+}

--- a/src/game/ai/leaders.ts
+++ b/src/game/ai/leaders.ts
@@ -1,0 +1,14 @@
+import { LeaderPersonality } from '../types';
+
+export const LEADER_PERSONALITIES: LeaderPersonality[] = [
+  { id: 'scientist', name: 'Scientist', aggression: 0.2, scienceFocus: 0.8, cultureFocus: 0.2, expansionism: 0.3 },
+  { id: 'culturalist', name: 'Culturalist', aggression: 0.2, scienceFocus: 0.2, cultureFocus: 0.8, expansionism: 0.3 },
+  { id: 'expansionist', name: 'Expansionist', aggression: 0.6, scienceFocus: 0.3, cultureFocus: 0.3, expansionism: 0.8 },
+  { id: 'balanced', name: 'Balanced', aggression: 0.4, scienceFocus: 0.5, cultureFocus: 0.5, expansionism: 0.5 },
+];
+
+export function getLeader(id: string): LeaderPersonality {
+  const found = LEADER_PERSONALITIES.find(l => l.id === id);
+  if (!found) throw new Error(`Unknown leader ${id}`);
+  return found;
+}

--- a/src/game/events.ts
+++ b/src/game/events.ts
@@ -6,6 +6,7 @@ export interface GameEvents {
   'turn:start': { turn: number };
   'turn:end': { turn: number };
   'action:applied': { action: GameAction };
+  'tech:unlocked': { playerId: string; techId: string };
 }
 
 export class GameEventBus<E extends Record<string, any>> {

--- a/src/game/tech/techCatalog.ts
+++ b/src/game/tech/techCatalog.ts
@@ -1,0 +1,28 @@
+import { TechNode } from '../types';
+
+export const techCatalog: TechNode[] = [
+  { id: 'pottery', tree: 'science', name: 'Pottery', cost: 20, prerequisites: [], effects: [] },
+  { id: 'writing', tree: 'science', name: 'Writing', cost: 40, prerequisites: ['pottery'], effects: [] },
+  { id: 'folklore', tree: 'culture', name: 'Folklore', cost: 20, prerequisites: [], effects: [] },
+  { id: 'mysticism', tree: 'culture', name: 'Mysticism', cost: 40, prerequisites: ['folklore'], effects: [] },
+];
+
+export function validateTechCatalog(catalog: TechNode[]): void {
+  const graph: Record<string, string[]> = {};
+  for (const node of catalog) {
+    graph[node.id] = node.prerequisites;
+  }
+  const visited = new Set<string>();
+  const stack = new Set<string>();
+  function dfs(id: string) {
+    if (stack.has(id)) throw new Error(`Tech cycle detected at ${id}`);
+    if (visited.has(id)) return;
+    visited.add(id);
+    stack.add(id);
+    for (const dep of graph[id] || []) dfs(dep);
+    stack.delete(id);
+  }
+  for (const id of Object.keys(graph)) dfs(id);
+}
+
+validateTechCatalog(techCatalog);

--- a/tests/ai.test.ts
+++ b/tests/ai.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateAI } from '../src/game/ai/ai';
+import { GameState, PlayerState } from '../src/game/types';
+import { techCatalog } from '../src/game/tech/techCatalog';
+import { LEADER_PERSONALITIES } from '../src/game/ai/leaders';
+
+function mockState(player: PlayerState): GameState {
+  return {
+    schemaVersion: 1,
+    seed: 's',
+    turn: 0,
+    map: { width: 1, height: 1, tiles: [] },
+    players: [player],
+    techCatalog,
+    rngState: undefined,
+    log: [],
+    mode: 'standard',
+    autoSim: false,
+  };
+}
+
+describe('AI evaluation', () => {
+  it('selects a tech without mutating state', () => {
+    const player: PlayerState = {
+      id: 'p1',
+      isHuman: false,
+      leader: LEADER_PERSONALITIES[0],
+      sciencePoints: 10,
+      culturePoints: 10,
+      researchedTechIds: [],
+      researching: null,
+    };
+    const state = mockState(player);
+    const snapshot = structuredClone(state);
+    const actions = evaluateAI(player, state);
+    expect(state).toEqual(snapshot);
+    expect(actions.length).toBeGreaterThan(0);
+    expect(actions[0].type).toBe('SET_RESEARCH');
+  });
+
+  it('prefers tech tree based on leader focus', () => {
+    const scientist: PlayerState = {
+      id: 'p1',
+      isHuman: false,
+      leader: LEADER_PERSONALITIES[0],
+      sciencePoints: 10,
+      culturePoints: 10,
+      researchedTechIds: [],
+      researching: null,
+    };
+    const scientistAction = evaluateAI(scientist, mockState(scientist))[0];
+    expect(scientistAction.payload.techId).toBe('pottery');
+
+    const culturalist: PlayerState = {
+      id: 'p2',
+      isHuman: false,
+      leader: LEADER_PERSONALITIES[1],
+      sciencePoints: 10,
+      culturePoints: 10,
+      researchedTechIds: [],
+      researching: null,
+    };
+    const culturalistAction = evaluateAI(culturalist, mockState(culturalist))[0];
+    expect(culturalistAction.payload.techId).toBe('folklore');
+  });
+});

--- a/tests/tech.test.ts
+++ b/tests/tech.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { validateTechCatalog, techCatalog } from '../src/game/tech/techCatalog';
+import { applyAction } from '../src/game/reducer';
+import { GameState, PlayerState } from '../src/game/types';
+import { LEADER_PERSONALITIES } from '../src/game/ai/leaders';
+import { globalGameBus } from '../src/game/events';
+
+function baseState(player: PlayerState): GameState {
+  return {
+    schemaVersion: 1,
+    seed: 's',
+    turn: 0,
+    map: { width: 1, height: 1, tiles: [] },
+    players: [player],
+    techCatalog,
+    rngState: undefined,
+    log: [],
+    mode: 'standard',
+    autoSim: false,
+  };
+}
+
+describe('tech system', () => {
+  it('detects cycles', () => {
+    expect(() =>
+      validateTechCatalog([
+        { id: 'a', tree: 'science', name: 'A', cost: 1, prerequisites: ['b'], effects: [] },
+        { id: 'b', tree: 'science', name: 'B', cost: 1, prerequisites: ['a'], effects: [] },
+      ])
+    ).toThrow();
+  });
+
+  it('enforces prerequisites and unlocks tech', () => {
+    const player: PlayerState = {
+      id: 'p1',
+      isHuman: false,
+      leader: LEADER_PERSONALITIES[3],
+      sciencePoints: 40,
+      culturePoints: 40,
+      researchedTechIds: ['pottery'],
+      researching: null,
+    };
+    let state = baseState(player);
+    state = applyAction(state, { type: 'SET_RESEARCH', playerId: 'p1', payload: { techId: 'writing' } });
+    expect(state.players[0].researching?.techId).toBe('writing');
+    state = applyAction(state, { type: 'END_TURN' });
+    expect(state.players[0].researchedTechIds).toContain('writing');
+  });
+
+  it('emits tech:unlocked when research completes', () => {
+    const player: PlayerState = {
+      id: 'p1',
+      isHuman: false,
+      leader: LEADER_PERSONALITIES[3],
+      sciencePoints: 40,
+      culturePoints: 40,
+      researchedTechIds: ['pottery'],
+      researching: null,
+    };
+    let event: { playerId: string; techId: string } | undefined;
+    const off = globalGameBus.on('tech:unlocked', e => {
+      event = e;
+    });
+    let state = baseState(player);
+    state = applyAction(state, {
+      type: 'SET_RESEARCH',
+      playerId: 'p1',
+      payload: { techId: 'writing' },
+    });
+    applyAction(state, { type: 'END_TURN' });
+    off();
+    expect(event).toEqual({ playerId: 'p1', techId: 'writing' });
+  });
+
+  it('prevents research without prerequisites', () => {
+    const player: PlayerState = {
+      id: 'p1',
+      isHuman: false,
+      leader: LEADER_PERSONALITIES[3],
+      sciencePoints: 40,
+      culturePoints: 40,
+      researchedTechIds: [],
+      researching: null,
+    };
+    let state = baseState(player);
+    state = applyAction(state, { type: 'SET_RESEARCH', playerId: 'p1', payload: { techId: 'writing' } });
+    expect(state.players[0].researching).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add static tech tree catalog with cycle validation
- emit `tech:unlocked` events and auto research progression
- introduce leader personalities and basic AI research selection
- respect leader focus when choosing technologies

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68becc5c4310832abd2f37aa60a2cef6