### PR TITLE
feat(hex): support cylindrical wrap

### DIFF
--- a/src/components/ui/minimap-container.tsx
+++ b/src/components/ui/minimap-container.tsx
@@ -24,13 +24,13 @@ export default function MinimapContainer() {
   );
   const extension = state.contentExt;
   const highlighted = React.useMemo(() => {
-  if (!extension || !selectedUnitId) return [] as string[];
+    if (!extension || !selectedUnitId) return [] as string[];
     try {
-      return computeMovementRange(extension, selectedUnitId).reachable;
+      return computeMovementRange(extension, selectedUnitId, state.map.width, state.map.height).reachable;
     } catch {
       return [] as string[];
     }
-  }, [extension, selectedUnitId]);
+  }, [extension, selectedUnitId, state.map.height, state.map.width]);
   return (
     <Minimap
       width={state.map.width}

--- a/src/components/ui/unit-selection-overlay-container.tsx
+++ b/src/components/ui/unit-selection-overlay-container.tsx
@@ -13,8 +13,8 @@ export function UnitSelectionOverlayContainer({
 
   const range = useMemo(() => {
     if (!extension || !selectedUnitId) return { reachable: [], cost: {} as Record<string, number> };
-    return computeMovementRange(extension, selectedUnitId);
-  }, [extension, selectedUnitId]);
+    return computeMovementRange(extension, selectedUnitId, state.map.width, state.map.height);
+  }, [extension, selectedUnitId, state.map.height, state.map.width]);
 
   if (!selectedUnitId || !extension) return;
 
@@ -25,7 +25,7 @@ export function UnitSelectionOverlayContainer({
       computedPath={path}
       onPreviewPath={(targetTileId) => {
         if (!extension) return;
-        const result = computePath(extension, selectedUnitId, targetTileId);
+        const result = computePath(extension, selectedUnitId, targetTileId, state.map.width, state.map.height);
         if ('path' in result && result.path) setPath(result.path);else
         setPath(undefined);
       }}

--- a/src/game/pathfinder.ts
+++ b/src/game/pathfinder.ts
@@ -33,7 +33,9 @@ function passableFor(state: GameStateExtension, unit: Unit, tile: Hextile): bool
 export function computePath(
   state: GameStateExtension,
   unitId: string,
-  targetTileId: string
+  targetTileId: string,
+  width?: number,
+  height?: number
 ): { path: string[]; totalCost: number; combatPreview?: CombatPreview } | { path: null; totalCost: number } {
   const unit = state.units[unitId];
   const start = unit ? state.tiles[unit.location] : undefined;
@@ -60,7 +62,7 @@ export function computePath(
     const cid = pq.shift()!;
     if (cid === goal.id) break;
     const ct = state.tiles[cid];
-    const neighCoords = hexNeighbors({ q: ct.q, r: ct.r });
+    const neighCoords = hexNeighbors({ q: ct.q, r: ct.r }, width, height);
     for (const nc of neighCoords) {
       const nid = index.get(`${nc.q},${nc.r}`);
       if (!nid) continue;
@@ -126,7 +128,9 @@ export function computePath(
 }
 export function computeMovementRange(
   state: GameStateExtension,
-  unitId: string
+  unitId: string,
+  width?: number,
+  height?: number
 ): { reachable: string[]; cost: Record<string, number> } {
   const unit = state.units[unitId];
   const start = unit ? state.tiles[unit.location] : undefined;
@@ -150,7 +154,7 @@ export function computeMovementRange(
     const ccost = distribution.get(cid)!;
     if (ccost <= unit.movementRemaining && cid !== start.id) reachable.push(cid);
     const ct = state.tiles[cid];
-    const neighCoords = hexNeighbors({ q: ct.q, r: ct.r });
+    const neighCoords = hexNeighbors({ q: ct.q, r: ct.r }, width, height);
     for (const nc of neighCoords) {
       const nid = index.get(`${nc.q},${nc.r}`);
       if (!nid) continue;

--- a/src/game/utils/replay.ts
+++ b/src/game/utils/replay.ts
@@ -44,7 +44,7 @@ export function decodeBigIntMarkers<T>(object: T): T {
     const t = typeof v;
     if (t === 'string') {
       // match optional leading - then digits then 'n' marker
-      if (/^-?/d+n$/.test(v)) return BigInt(v.slice(0, -1));
+      if (/^-?\d+n$/.test(v)) return BigInt(v.slice(0, -1));
       return v;
     }
     if (t === 'object') {

--- a/src/game/world/hex.ts
+++ b/src/game/world/hex.ts
@@ -13,8 +13,18 @@ export function add(a: HexCoord, b: HexCoord): HexCoord {
   return { q: a.q + b.q, r: a.r + b.r };
 }
 
-export function neighbors(c: HexCoord): HexCoord[] {
-  return HEX_DIRECTIONS.map((d) => add(c, d));
+export function neighbors(c: HexCoord, width?: number, height?: number): HexCoord[] {
+  return HEX_DIRECTIONS.map((d) => {
+    let q = c.q + d.q;
+    let r = c.r + d.r;
+    if (typeof width === 'number') {
+      q = ((q % width) + width) % width;
+    }
+    if (typeof height === 'number') {
+      r = ((r % height) + height) % height;
+    }
+    return { q, r };
+  });
 }
 
 export function distance(a: HexCoord, b: HexCoord): number {

--- a/src/scene/utils/coords.ts
+++ b/src/scene/utils/coords.ts
@@ -2,20 +2,19 @@
  * Convert axial hex coordinates (q, r) to world X/Z plane coordinates.
  * Orientation: flat-top hexes (flat sides on top/bottom).
  *
- * Projection: Cylindrical world layout (modified for seamless wrapping)
- *  - Creates evenly spaced columns for cylindrical world wrapping
- *  - Removes the odd-q offset to ensure columns align vertically
- *  - Maintains axial math (neighbors, distance, pathfinding) unchanged
+ * Projection: standard flat-top axial layout with vertical staggering.
+ *  - Columns wrap horizontally for a cylindrical world.
+ *  - Vertical coordinate accounts for the odd-q offset (r + q/2).
  *
  * Formulas (flat-top, cylindrical):
  *   worldX = size * 3/2 * q
- *   worldZ = size * sqrt(3) * r
+ *   worldZ = size * sqrt(3) * (r + q / 2)
  *
  * `size` is the hex radius (distance from center to any corner).
  */
 export function axialToWorld(q: number, r: number, size = 1): [number, number] {
   const worldX = size * (3 / 2) * q;
-  const worldZ = size * Math.sqrt(3) * r;
+  const worldZ = size * Math.sqrt(3) * (r + q / 2);
   return [worldX, worldZ];
 }
 

--- a/tests/pathfinder_wraparound.test.ts
+++ b/tests/pathfinder_wraparound.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import { applyAction } from '../src/game/reducer';
-import { initialState } from "../src/contexts/game-provider";
+import { initialState } from '../src/contexts/game-provider';
 import { computePath } from '../src/game/pathfinder';
 
-describe('computePath totalCost', () => {
-  it('computes cost across grassland chain', () => {
+describe('computePath wrap-around', () => {
+  it('allows wrapping horizontally across edges', () => {
     let s = initialState();
+    s.map.width = 3;
+    s.map.height = 1;
     s = applyAction(s, {
       type: 'EXT_ADD_TILE',
       payload: { tile: { id: 'a', q: 0, r: 0, biome: 'grassland' } }
@@ -19,18 +21,13 @@ describe('computePath totalCost', () => {
       payload: { tile: { id: 'c', q: 2, r: 0, biome: 'grassland' } }
     });
     s = applyAction(s, {
-      type: 'EXT_ADD_CITY',
-      payload: { cityId: 'home', name: 'H', ownerId: 'P', tileId: 'a' }
-    });
-    s = applyAction(s, {
       type: 'EXT_ADD_UNIT',
       payload: { unitId: 'u1', type: 'warrior', ownerId: 'P', tileId: 'a' }
     });
     const res = computePath(s.contentExt!, 'u1', 'c', s.map.width, s.map.height);
     if ('path' in res && res.path) {
-      expect(res.path[0]).toBe('a');
-      expect(res.path.at(-1)).toBe('c');
-      expect(res.totalCost).toBe(2);
+      expect(res.path).toEqual(['a', 'c']);
+      expect(res.totalCost).toBe(1);
     } else {
       throw new Error('path not found');
     }

--- a/tests/preview_combat_flag.test.ts
+++ b/tests/preview_combat_flag.test.ts
@@ -31,7 +31,7 @@ describe('computePath combat preview', () => {
       payload: { unitId: 'e1', type: 'warrior', ownerId: 'E', tileId: 'c' }
     });
 
-    const res: any = computePath(s.contentExt!, 'u1', 'c');
+    const res: any = computePath(s.contentExt!, 'u1', 'c', s.map.width, s.map.height);
     expect(res.path).toBeTruthy();
     expect(res.totalCost).toBeGreaterThanOrEqual(2);
     expect(res.combatPreview).toBeTruthy();


### PR DESCRIPTION
## Summary
- stagger axial hex projection for cylindrical worlds
- wrap hex neighbor lookup and pathfinding across map edges
- test horizontal wrap-around

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2c0be41b4832a8ce537a99df652a8