### PR TITLE
fix: populate tiles and implement move path

### DIFF
--- a/src/game/content/rules.ts
+++ b/src/game/content/rules.ts
@@ -93,11 +93,15 @@ export function moveUnit(state: GameStateExtension, unitId: string, toTileId: st
   const unitType = UNIT_TYPES[unit.type];
   if (!unitType) return false;
   if (!canUnitEnter(state, unit, tile)) return false;
+  const fromTileId = typeof unit.location === 'string' ? unit.location : '';
+  const fromTile = fromTileId ? state.tiles[fromTileId] : undefined;
   const cost = movementCost(tile, { unitAbilities: unit.abilities, unitDomain: unitType.domain });
   const step = roundUp(cost);
   if (step <= unit.movementRemaining) {
     unit.movementRemaining -= step;
+    if (fromTile && fromTile.occupantUnitId === unit.id) fromTile.occupantUnitId = null;
     unit.location = tile.id;
+    tile.occupantUnitId = unit.id;
     return true;
   }
   return false;

--- a/tests/ui.interaction-move.test.ts
+++ b/tests/ui.interaction-move.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { applyAction } from '../src/game/reducer';
+import { initialState } from '../src/contexts/game-provider';
+import { computeMovementRange } from '../src/game/pathfinder';
+
+describe('UI interaction movement flow', () => {
+  it('selects unit, previews path and issues move', () => {
+    let state = initialState();
+    state = applyAction(state, {
+      type: 'NEW_GAME',
+      payload: { seed: 'test', totalPlayers: 1, humanPlayers: 1 }
+    });
+    const ext = state.contentExt!;
+    const unitId = Object.keys(ext.units)[0];
+    const range = computeMovementRange(ext, unitId, state.map.width, state.map.height);
+    expect(range.reachable.length).toBeGreaterThan(0);
+    const target = range.reachable[0];
+    state = applyAction(state, { type: 'SELECT_UNIT', payload: { unitId } });
+    state = applyAction(state, { type: 'PREVIEW_PATH', payload: { unitId, targetTileId: target } });
+    const path = state.ui.previewPath!;
+    state = applyAction(state, { type: 'ISSUE_MOVE', payload: { unitId, path } });
+    expect(state.contentExt!.units[unitId].location).toBe(target);
+    expect(state.ui.selectedUnitId).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- populate extension tiles from world map for pathfinding
- skip starting tile when previewing and issuing movement paths
- update unit movement to refresh tile occupants
- add test covering unit selection and movement flow

## Testing
- `npx vitest run tests/ui.interaction-move.test.ts`
- `npm run lint`
- `npm run test:e2e` *(fails: Host system is missing dependencies to run browsers)*

------
https://chatgpt.com/codex/tasks/task_e_68c35c675e6c832a8762e45dda6b511d