### PR TITLE
test: add deterministic replay verification

### DIFF
--- a/docs/replay-verification.md
+++ b/docs/replay-verification.md
@@ -1,0 +1,24 @@
+# Replay Verification
+
+This guide covers automated deterministic replay checks.
+
+## Running the test
+
+```bash
+npm test tests/deterministic-replay.test.ts
+```
+
+The test runs a set of randomized seeds (default 10). To use more seeds, set
+`REPLAY_SEEDS`:
+
+```bash
+REPLAY_SEEDS=50 npm test tests/deterministic-replay.test.ts
+```
+
+If a mismatch is detected, a reproduction file is written to
+`test-results/replay-failure-<seed>.json`.
+
+## CI notes
+
+The test is lightweight by default but can be configured with a higher seed
+count in CI to surface non-deterministic behavior.

--- a/memory-bank/tasks/TASK051-deterministic-replay.md
+++ b/memory-bank/tasks/TASK051-deterministic-replay.md
@@ -1,6 +1,6 @@
 # [TASK-051] Deterministic replay harness verification
 
-**Status:** Not Started
+**Status:** Completed on 2025-09-12
 
 **Added:** 2025-09-12
 
@@ -30,9 +30,9 @@ Plan marks deterministic replay as complete but notes that automated verificatio
 
 ## Tasks
 
-- [ ] Add `tests/deterministic-replay.test.ts` with basic K=10 run and replay assertions.
-- [ ] Add `docs/replay-verification.md` with run instructions and CI notes.
-- [ ] Add small utility `tests/utils/replay-helper.ts` if helpful to isolate record/replay logic.
+- [x] Add `tests/deterministic-replay.test.ts` with basic K=10 run and replay assertions.
+- [x] Add `docs/replay-verification.md` with run instructions and CI notes.
+- [x] Add small utility `tests/utils/replay-helper.ts` if helpful to isolate record/replay logic.
 
 ## ETA
 

--- a/memory-bank/tasks/_index.md
+++ b/memory-bank/tasks/_index.md
@@ -5,8 +5,7 @@
 
 
 ## Pending
- 
-- [TASK051] Deterministic replay verification - Add Vitest/utility for seedable RNG validation and replay tests
+
 - [TASK052..054] Performance benchmarks & rendering - Bench instanced vs non-instanced rendering and collect metrics
 - [TASK047..049] HUD accessibility & keyboard tests - Playwright/Vitest axe scans and keyboard focus tests for HUD
 - [TASK055..057] CI & E2E stability - Investigate flaky tests, improve Playwright resilience, and CI test stability
@@ -15,5 +14,6 @@
 
 - [TASK000] Project setup - Completed on 2025-09-10
 - [TASK032-033] AI micro-benchmarks - Completed on 2025-09-12
+- [TASK051] Deterministic replay verification - Completed on 2025-09-12
 
 ## Abandoned

--- a/tests/deterministic-replay.test.ts
+++ b/tests/deterministic-replay.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { verifyReplay } from './utils/replay-helper';
+
+const K = Number(process.env.REPLAY_SEEDS ?? 10);
+
+describe('deterministic replay verification', () => {
+  for (let index = 0; index < K; index++) {
+    const seed = `seed-${index}`;
+    it(`replays seed ${seed}`, async () => {
+      const ok = await verifyReplay(seed);
+      expect(ok).toBe(true);
+    });
+  }
+});

--- a/tests/utils/replay-helper.ts
+++ b/tests/utils/replay-helper.ts
@@ -1,0 +1,56 @@
+import { initialStateForTests } from '../../src/test-utils/game-provider';
+import { record, runReplay, hashState } from '../../src/game/utils/replay';
+import { applyAction } from '../../src/game/reducer';
+import { seedFrom, nextInt } from '../../src/game/rng';
+import type { GameAction } from '../../src/game/actions';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Runs a deterministic simulation for a given seed and verifies replay consistency.
+ * Writes a reproduction log to test-results on mismatch.
+ * @returns true if the replay hash matches the direct run.
+ */
+export async function verifyReplay(seed: string): Promise<boolean> {
+  const initial = initialStateForTests();
+  let state = initial;
+  const actions: GameAction[] = [];
+  let rng = seedFrom(seed);
+
+  // Randomize map size and turn count based on RNG
+  let out = nextInt(rng, 4);
+  rng = out.state;
+  const width = 8 + out.value;
+  out = nextInt(rng, 4);
+  rng = out.state;
+  const height = 8 + out.value;
+  out = nextInt(rng, 3);
+  rng = out.state;
+  const turns = 1 + out.value;
+
+  const newGame = {
+    type: 'NEW_GAME',
+    payload: { seed, width, height, totalPlayers: 1 },
+  } as GameAction;
+  actions.push(newGame);
+  state = applyAction(state, newGame as any);
+
+  for (let index = 0; index < turns; index++) {
+    const endTurn = { type: 'END_TURN' } as GameAction;
+    actions.push(endTurn);
+    state = applyAction(state, endTurn as any);
+  }
+
+  const replay = record(...actions);
+  const result = await runReplay(initial, replay);
+  const expectedHash = await hashState(state);
+  if (result.hash !== expectedHash) {
+    mkdirSync('test-results', { recursive: true });
+    writeFileSync(
+      join('test-results', `replay-failure-${seed}.json`),
+      JSON.stringify({ seed, actions }, null, 2)
+    );
+    return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
- add helper to verify replay determinism across seeds and log failures
- document replay verification and how to run tests
- mark TASK051 deterministic replay verification as complete

## Testing
- `npm run lint`
- `npm test tests/deterministic-replay.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68c42e712c8c832abf436520b707a267