### PR TITLE
feat(schema): validate new game actions

### DIFF
--- a/memory-bank/tasks/TASK061-update-schemas-and-add-new-actions.md
+++ b/memory-bank/tasks/TASK061-update-schemas-and-add-new-actions.md
@@ -1,7 +1,7 @@
 # TASK061 - Update Schemas and Add New Actions
 
-**Status:** Pending  
-**Added:** 2025-09-13  
+**Status:** Completed
+**Added:** 2025-09-13
 **Updated:** 2025-09-13
 
 ## Original Request
@@ -23,21 +23,22 @@ Schemas ensure runtime validation. This task centralizes new action definitions 
 
 ## Progress Tracking
 
-**Overall Status:** Not Started - 0%
+**Overall Status:** Completed - 100%
 
 ### Subtasks
 
 | ID | Description | Status | Updated | Notes |
 |----|-------------|--------|---------|-------|
-| 61.1 | Define new action payloads | Not Started |  |  |
-| 61.2 | Update ISSUE_MOVE schema | Not Started |  |  |
-| 61.3 | Integrate new actions into GameActionSchema | Not Started |  |  |
-| 61.4 | Update reducers for new actions | Not Started |  |  |
-| 61.5 | Add schema validation tests | Not Started |  |  |
-| 61.6 | Update existing action tests | Not Started |  |  |
+| 61.1 | Define new action payloads | Completed | 2025-09-13 | |
+| 61.2 | Update ISSUE_MOVE schema | Completed | 2025-09-13 | |
+| 61.3 | Integrate new actions into GameActionSchema | Completed | 2025-09-13 | |
+| 61.4 | Update reducers for new actions | Completed | 2025-09-13 | already handled in previous tasks |
+| 61.5 | Add schema validation tests | Completed | 2025-09-13 | |
+| 61.6 | Update existing action tests | Completed | 2025-09-13 | |
 
 ## Progress Log
 
 ### 2025-09-13
 
 - Task created based on plan-full-ui-logic.md
+- Added schemas and tests for REORDER_PRODUCTION_QUEUE, CANCEL_PRODUCTION_ORDER, SWITCH_RESEARCH_POLICY, and ISSUE_MOVE confirmCombat flag

--- a/memory-bank/tasks/_index.md
+++ b/memory-bank/tasks/_index.md
@@ -4,7 +4,6 @@
 
 ## Pending
 
-- [TASK061] Update Schemas and Add New Actions - REORDER_PRODUCTION_QUEUE, CANCEL_PRODUCTION_ORDER, SWITCH_RESEARCH_POLICY, ISSUE_MOVE updates
 - [TASK062] Add Testing for UI Interactions - Unit, integration, and E2E tests for new UI features
 
 ## Completed
@@ -20,6 +19,7 @@
 - [TASK058] Implement Unit Movement UI - Selection, range, path preview, combat, and movement execution - Completed on 2025-09-13
 - [TASK059] Implement City Production Selection UI - Panels, item display, queue management, target tiles - Completed on 2025-09-13
 - [TASK060] Implement Research Selection UI - Tech tree display, selection, queuing, policy switching - Completed on 2025-09-13
+- [TASK061] Update Schemas and Add New Actions - REORDER_PRODUCTION_QUEUE, CANCEL_PRODUCTION_ORDER, SWITCH_RESEARCH_POLICY, ISSUE_MOVE updates - Completed on 2025-09-13
 
 ## Abandoned
 

--- a/schema/action.schema.ts
+++ b/schema/action.schema.ts
@@ -1,6 +1,13 @@
 import { z } from 'zod';
 import { UnitState } from '../src/types/unit';
 const UnitStateSchema = z.nativeEnum(UnitState);
+const ProductionOrderSchema = z.object({
+  type: z.enum(['unit', 'improvement', 'building']),
+  item: z.string(),
+  turnsRemaining: z.number().optional(),
+  turns: z.number().optional(),
+  targetTileId: z.string().optional(),
+});
 
 export const MoveActionSchema = z.object({ type: z.literal('move'), unitId: z.string(), path: z.array(z.string()) });
 export const AttackActionSchema = z.object({
@@ -43,6 +50,30 @@ export const IssueMoveActionSchema = z.object({
   }),
 });
 
+export const ReorderProductionQueueActionSchema = z.object({
+  type: z.literal('REORDER_PRODUCTION_QUEUE'),
+  payload: z.object({
+    cityId: z.string(),
+    reorderedQueue: z.array(ProductionOrderSchema),
+  }),
+});
+
+export const CancelProductionOrderActionSchema = z.object({
+  type: z.literal('CANCEL_PRODUCTION_ORDER'),
+  payload: z.object({
+    cityId: z.string(),
+    orderIndex: z.number(),
+  }),
+});
+
+export const SwitchResearchPolicyActionSchema = z.object({
+  type: z.literal('SWITCH_RESEARCH_POLICY'),
+  payload: z.object({
+    playerId: z.string(),
+    policy: z.enum(['preserveProgress', 'discardProgress']),
+  }),
+});
+
 export const GameActionSchema = z.discriminatedUnion('type', [
   MoveActionSchema,
   AttackActionSchema,
@@ -57,6 +88,9 @@ export const GameActionSchema = z.discriminatedUnion('type', [
   AddUnitStateActionSchema,
   RemoveUnitStateActionSchema,
   IssueMoveActionSchema,
+  ReorderProductionQueueActionSchema,
+  CancelProductionOrderActionSchema,
+  SwitchResearchPolicyActionSchema,
 ]);
 
 // permissive catch-all for runtime events that are not strict game actions

--- a/tests/action-validation.test.ts
+++ b/tests/action-validation.test.ts
@@ -1,26 +1,12 @@
 import { expect, test } from 'vitest';
 import { GameActionSchema, AnyActionSchema } from '../schema/action.schema';
 
-test('valid move action passes strict schema', () => {
+test('valid move action passes schema', () => {
   const move = { type: 'move', unitId: 'u1', path: ['t1', 't2'] };
   expect(() => GameActionSchema.parse(move)).not.toThrow();
 });
 
-test('log event accepted by permissive schema and included in GameActionSchema', () => {
-  const log = { type: 'LOG_EVENT', payload: { entry: { timestamp: Date.now(), type: 'turn:start' } } };
-  expect(() => AnyActionSchema.parse(log)).not.toThrow();
-  // GameActionSchema should also accept LOG_EVENT after schema extension
-  expect(() => GameActionSchema.parse(log)).not.toThrow();
-});
-import { expect, test } from 'vitest';
-import { GameActionSchema } from '../schema/action.schema';
-
-test('valid move action passes schema', () => {
-  const a = { type: 'move', unitId: 'u1', path: ['t1', 't2'] };
-  expect(() => GameActionSchema.parse(a as any)).not.toThrow();
-});
-
-test('invalid move action (missing unitId) fails schema', () => {
+test('invalid move action fails schema', () => {
   const a = { type: 'move', path: ['t1'] };
   expect(() => GameActionSchema.parse(a as any)).toThrow();
 });
@@ -29,3 +15,48 @@ test('endTurn action passes', () => {
   const a = { type: 'endTurn' };
   expect(() => GameActionSchema.parse(a as any)).not.toThrow();
 });
+
+test('log event accepted by permissive schema and included in GameActionSchema', () => {
+  const log = { type: 'LOG_EVENT', payload: { entry: { timestamp: Date.now(), type: 'turn:start' } } };
+  expect(() => AnyActionSchema.parse(log)).not.toThrow();
+  expect(() => GameActionSchema.parse(log)).not.toThrow();
+});
+
+test('reorder production queue action passes schema', () => {
+  const a = {
+    type: 'REORDER_PRODUCTION_QUEUE',
+    payload: {
+      cityId: 'c1',
+      reorderedQueue: [
+        { type: 'unit', item: 'warrior' },
+        { type: 'building', item: 'granary', turns: 3 },
+      ],
+    },
+  };
+  expect(() => GameActionSchema.parse(a as any)).not.toThrow();
+});
+
+test('cancel production order action passes schema', () => {
+  const a = {
+    type: 'CANCEL_PRODUCTION_ORDER',
+    payload: { cityId: 'c1', orderIndex: 0 },
+  };
+  expect(() => GameActionSchema.parse(a as any)).not.toThrow();
+});
+
+test('switch research policy action passes schema', () => {
+  const a = {
+    type: 'SWITCH_RESEARCH_POLICY',
+    payload: { playerId: 'p1', policy: 'discardProgress' },
+  };
+  expect(() => GameActionSchema.parse(a as any)).not.toThrow();
+});
+
+test('ISSUE_MOVE with confirmCombat passes schema', () => {
+  const a = {
+    type: 'ISSUE_MOVE',
+    payload: { unitId: 'u1', path: ['t1', 't2'], confirmCombat: true },
+  };
+  expect(() => GameActionSchema.parse(a as any)).not.toThrow();
+});
+


### PR DESCRIPTION
## Summary
- extend action schemas for production queue reordering, canceling orders, and switching research policy
- cover new schemas and IssueMove confirmCombat with unit tests
- mark TASK061 as complete in project memory

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5c70994ec832a926b3db912eb7627